### PR TITLE
delete unnecessary code

### DIFF
--- a/models/transformer.py
+++ b/models/transformer.py
@@ -111,12 +111,9 @@ class TransformerDecoder(nn.Module):
                            pos=pos, query_pos=query_pos)
             if self.return_intermediate:
                 intermediate.append(self.norm(output))
-
+        
         if self.norm is not None:
             output = self.norm(output)
-            if self.return_intermediate:
-                intermediate.pop()
-                intermediate.append(output)
 
         if self.return_intermediate:
             return torch.stack(intermediate)


### PR DESCRIPTION
 if self.return_intermediate is enabled, the line 117 - 119 are not necessary, whose function has been covered by line 112 - 113 already.